### PR TITLE
Update default.py

### DIFF
--- a/default.py
+++ b/default.py
@@ -24,7 +24,6 @@ sys.path.append(librerias)
 from platformcode import launcher
 
 if sys.argv[2] == "":
-    launcher.start()
     launcher.run()
 else:
     launcher.run()


### PR DESCRIPTION
The function launcher.start() is not functional.
This cause that the addon does not start on Kodi for Linux.

---
Error Type: <type 'exceptions.ImportError'>
Error Contents: No module named ordered_dict
Traceback (most recent call last):
       File "/home/johndoe/.kodi/addons/plugin.video.kod/default.py", line 25, in <module>
                                                launcher.start()
---

Commenting out the function, the addon start to work again.