### PR TITLE
Fix Autoplay Blocked-Servers list

### DIFF
--- a/specials/setting.py
+++ b/specials/setting.py
@@ -241,7 +241,7 @@ def server_debrid_config(item):
 
 def servers_blacklist(item):
     server_list = servertools.get_servers_list()
-    black_list = config.get_setting("black_list", server='servers')
+    black_list = config.get_setting("black_list", server='servers', default=[])
     blacklisted = []
 
     list_controls = []


### PR DESCRIPTION
An error occurred when trying to set a blocked-server for the autoplay. It was a type error due to a list parsing on a variable which had a "None" type. The fix consists in setting a fallback value different than "None" when retrieving the block_list variable.