### PR TITLE
Add another mixdrop domain regexp

### DIFF
--- a/servers/mixdrop.json
+++ b/servers/mixdrop.json
@@ -10,6 +10,10 @@
       {
         "pattern": "(mixdro?ps?.[^/]+/player\\.php\\?id=[a-z0-9-]+)",
         "url": "https://\\1"
+      },
+      {
+        "pattern": "(mdy.[^/]+/(?:f|e)/[a-z0-9]+)",
+        "url": "https://\\1"
       }
     ]
   },

--- a/servers/mixdrop.json
+++ b/servers/mixdrop.json
@@ -12,7 +12,7 @@
         "url": "https://\\1"
       },
       {
-        "pattern": "(mdy.[^/]+/(?:f|e)/[a-z0-9]+)",
+        "pattern": "(mdy[a-z0-9]*\\.[a-z0-9]+/(?:f|e)/[a-z0-9]+)",
         "url": "https://\\1"
       }
     ]


### PR DESCRIPTION
Aggiunto un nuovo dominio compatibile con il server mixdrop rilevato tramite log (modificati un po per capire meglio dove fosse l'errore)

https://mdy48tn97.com

La regular expression può sembra corta, ma ho immaginato che cercare 'mdy' fosse sufficiente visto che difficilmente il canale punterebbe ad un server che non sia mixdrop

```
2023-11-09 18:16:03.259 T:5479     info <general>: kod[support.server:1267] 
2023-11-09 18:16:03.260 T:5479     info <general>: kod[servertools.find_video_items:43] 
2023-11-09 18:16:03.261 T:5479     info <general>: kod[servertools.find_video_items:46]:  download link ['https://mdy48tn97.com/e/xomqe37lfqv7o4']
2023-11-09 18:16:03.381 T:5479     info <general>: kod[unshortenit.findlinks:799]:  matches=[]
2023-11-09 18:16:03.388 T:5479     info <general>: kod[servertools.findvideos:141] 
2023-11-09 18:16:04.741 T:5479     info <general>: kod[servertools.findvideosbyserver:178]:  mixdrop
                                                   pattern: (mdy.[^/]+/(?:f|e)/[a-z0-9]+)
                                                   found url: https://mdy48tn97.com/e/xomqe37lfqv7o4
2023-11-09 18:16:04.880 T:5482     info <general>: kod[channeltools.get_channel_json:90]:  channel_name=streamingita
2023-11-09 18:16:04.883 T:5482     info <general>: kod[channeltools.get_channel_json:104]:  channel_data=/storage/.kodi/addons/plugin.video.kod/channels/streamingita.json
```

ciao