### PR TITLE
altadefinizione: fix title, lang and others

### DIFF
--- a/channels/altadefinizione.py
+++ b/channels/altadefinizione.py
@@ -19,7 +19,7 @@ headers = [['Referer', host]]
 @support.menu
 def mainlist(item):
 
-    film = ['',
+    film = ['/category/film/',
             ('Al Cinema', ['/category/ora-al-cinema/', 'peliculas']),
             ('Generi', ['', 'genres']),
             # ('Sub-ITA', ['/sub-ita/', 'peliculas'])
@@ -51,7 +51,7 @@ def genres(item):
 
 def search(item, text):
     logger.debug(text)
-    item.url = "{}/?s={}".format(host, text)
+    item.url = "{}/?{}".format(host, support.urlencode({'s': text}))
     item.args = 'search'
 
     try:
@@ -68,10 +68,10 @@ def search(item, text):
 def peliculas(item):
     item.contentType = "undefined"
     action = 'check'
-    patron = r'<h2 class=\"titleFilm\"><a href=\"(?P<url>[^\"]+)\">(?P<title>[a-zA-Z\d\s&#8217;&#8211;:\.-]*)\s*\[?(?P<quality>[a-zA-Z]*)\]?\s*\(?(?P<year>[0-9]*)\)?'
+    patron = r'<h2 class=\"titleFilm\"><a href=\"(?P<url>[^\"]+)\">(?P<title>[\'’\+A-Za-zÀ-ÿ\d\s&#8217;&#8211;:\.-]*)\s*\(?(?P<lang>[a-zA-Z-]*)\)?\[?(?P<quality>[a-zA-Z]*)\]?\s*\(?(?P<year>[0-9]*)\)?'
 
     if item.args == 'search':
-          patron = r'<div class="col-lg-3 col-md-3 [^>]*> <a href=\"(?P<url>[^\"]+)\">.*?(?=<h5).*?(?=>)>(?P<title>[a-zA-Z\d\s&#8217;&#8211;:\.\'-]*)\s*\[?(?P<quality>[a-zA-Z]*)\]?\s*\(?(?P<year>[0-9]*)\)?'
+          patron = r'<div class="col-lg-3 col-md-3 [^>]*> <a href=\"(?P<url>[^\"]+)\">.*?(?=<h5).*?(?=>)>(?P<title>[\'’\+A-Za-zÀ-ÿ\d\s&#8217;&#8211;:\.-]*)\s*\(?(?P<lang>[a-zA-Z-]*)\)?\[?(?P<quality>[a-zA-Z]*)\]?\s*\(?(?P<year>[0-9]*)\)?'
     patronNext = r'href="([^"]+)[^>]+>Successivo'
     return locals()
 
@@ -81,7 +81,7 @@ def episodios(item):
     item.quality = ''
     data = item.data
     action='findvideos'
-    patron = r'<div class="episode-wrap".*?(?=<li class="season-no">).*?(?=>)>(?P<episode>[^<]+).*?(?=<a)<a href="(?P<url>[^\"]+).*?(?=>)>(?P<title>[a-zA-Z\d\s&#8217;&#8211;:\.\'-]*)'
+    patron = r'<div class="episode-wrap".*?(?=<li class="season-no">).*?(?=>)>(?P<episode>[^<]+).*?(?=<a)<a href="(?P<url>[^\"]+).*?(?=>)>(?P<title>[\'’\+A-Za-zÀ-ÿ\d\s&#8217;&#8211;:\.-]*)'
     return locals()
 
 
@@ -95,12 +95,12 @@ def check(item):
 
 
 def findvideos(item):
-    logger.debug()
-    #support.dbg()
-    if not item.data:
-        item.data = httptools.downloadpage(item.url).data
-    data = item.data
-    if item.contentType == 'movie' and isinstance(item.data, str):
-        data = support.match(support.match(item.data, patron=r'<div class="embed-player" data-id=\"(https://.*?)\"').match).data
-    item.data = ''
-    return support.server(item, data)
+    video_url = item.url
+
+    if item.contentType == 'movie':
+        video_url = support.match(item, patron=r'<div class="embed-player" data-id=\"(https://.*?)\"').match
+
+    itemlist = [item.clone(action="play", url=srv) for srv in support.match(video_url, patron='<div class="megaButton" meta-type="v" meta-link="([^"]+).*?(?=>)>').matches]
+    itemlist = support.server(item,itemlist=itemlist)
+    
+    return itemlist

--- a/channels/altadefinizione.py
+++ b/channels/altadefinizione.py
@@ -68,10 +68,10 @@ def search(item, text):
 def peliculas(item):
     item.contentType = "undefined"
     action = 'check'
-    patron = r'<h2 class=\"titleFilm\"><a href=\"(?P<url>[^\"]+)\">(?P<title>[\'’\+A-Za-zÀ-ÿ\d\s&#8217;&#8211;:\.-]*)\s*\(?(?P<lang>[a-zA-Z-]*)\)?\[?(?P<quality>[a-zA-Z]*)\]?\s*\(?(?P<year>[0-9]*)\)?'
+    patron = r'<h2 class=\"titleFilm\"><a href=\"(?P<url>[^\"]+)\">(?P<title>[^<[(]+)\s*\(?(?P<lang>[a-zA-Z-]*)\)?\s*\[?(?P<quality>[a-zA-Z]*)\]?\s*\(?(?P<year>[0-9]*)\)?'
 
     if item.args == 'search':
-          patron = r'<div class="col-lg-3 col-md-3 [^>]*> <a href=\"(?P<url>[^\"]+)\">.*?(?=<h5).*?(?=>)>(?P<title>[\'’\+A-Za-zÀ-ÿ\d\s&#8217;&#8211;:\.-]*)\s*\(?(?P<lang>[a-zA-Z-]*)\)?\[?(?P<quality>[a-zA-Z]*)\]?\s*\(?(?P<year>[0-9]*)\)?'
+          patron = r'<div class="col-lg-3 col-md-3 [^>]*> <a href=\"(?P<url>[^\"]+)\">.*?(?=<h5).*?(?=>)>(?P<title>[^<[(]+)\s*\(?(?P<lang>[a-zA-Z-]*)\)?\s*\[?(?P<quality>[a-zA-Z]*)\]?\s*\(?(?P<year>[0-9]*)\)?'
     patronNext = r'href="([^"]+)[^>]+>Successivo'
     return locals()
 
@@ -81,7 +81,7 @@ def episodios(item):
     item.quality = ''
     data = item.data
     action='findvideos'
-    patron = r'<div class="episode-wrap".*?(?=<li class="season-no">).*?(?=>)>(?P<episode>[^<]+).*?(?=<a)<a href="(?P<url>[^\"]+).*?(?=>)>(?P<title>[\'’\+A-Za-zÀ-ÿ\d\s&#8217;&#8211;:\.-]*)'
+    patron = r'<div class="episode-wrap".*?(?=<li class="season-no">).*?(?=>)>(?P<episode>[^<]+).*?(?=<a)<a href="(?P<url>[^\"]+).*?(?=>)>(?P<title>[^<[(]+)'
     return locals()
 
 


### PR DESCRIPTION
Scusate ma nella fix per altadefinizione https://github.com/kodiondemand/addon/pull/452 ci sono un paio di sviste che elenco

- mancata paginazione. Il portale non la prevede per tutte le pagine (compresa la ricerca) ma ove possibile è stato fixato
- migliorata regexp per lo scrape del titolo (il portale adotta diverse convenzioni per alcuni caratteri, es l'apostrofo)
- urlencode dei parametri usati per la ricerca (ad esempio il '+')
- migliorata ricerca servers

grazie
p.s. sostituisce questa https://github.com/kodiondemand/addon/pull/453