### PR TITLE
mixdrop: include another path

### DIFF
--- a/servers/mixdrop.json
+++ b/servers/mixdrop.json
@@ -4,7 +4,7 @@
     "ignore_urls": [],
     "patterns": [
       {
-        "pattern": "mixdro?o?ps?.[^/]+/(?:f|e)/([a-z0-9]+)",
+        "pattern": "mixdro?o?ps?.[^/]+/(?:f|e|emb)/([a-z0-9]+)",
         "url": "https://mixdrop.ag/e/\\1"
       },
       {


### PR DESCRIPTION
Aggiunto un nuovo path valido per mixdrop (esempio https://mixdrop.cfd/emb/zpmqjl49hgmo39l)