### PR TITLE
Update la7.py with program preview

### DIFF
--- a/channels/la7.py
+++ b/channels/la7.py
@@ -141,6 +141,63 @@ def peliculas(item):
     if 'la7teche' in item.url:
         patron = r'<a href="(?P<url>[^"]+)" title="(?P<title>[^"]+)" class="teche-i-img".*?url\(\'(?P<thumb>[^\']+)'
     else:
+        tids = {'/fa-che-io-sia-lultima': '115013', '/100minuti': '115737', '/atelechiavi': '84090', '/ai-il-futuro': '114921', '/amarsi-un-po': '115239', '/amgstories': '112885',
+             '/amoristonati': '79999', '/artbox': '104964', '/atlantide': '27381', '/atlantidefiles': '87126', '/barbero-risponde': '118666', '/bellitalia-in-viaggio': '102099',
+             '/bellidentrobellifuori': '82353', '/bersaglio-mobile': '45819', '/bull': '115680', '/buongiornomondo': '119675', '/c-era-una-volta': '111648', '/cera-una-volta-il-novecento': '111932',
+             '/cambio-cuoco': '75628', '/camera-con-vista': '81722', '/cercasiautodisperatamente': '82794', '/coffee-break': '27592', '/cristina-parodi-live': '27533',
+             '/crozza': '25457', '/cuochi-e-fiamme': '33163', '/defining-class-since-1886': '114836', '/diciannovequaranta': '59402', '/dimartedi': '59403', '/dizionario-del-tempo-presente': '101035',
+             '/donne-vittime-e-carnefici': '33198', '/donne-storie-che-ispirano': '96013', '/downton-abbey': '106972', '/drink-me-out': '86027', '/eccezionale-veramente': '69716',
+             '/eccezionale-veramente-2017': '74976', '/eccezionale-veramente-ma-veramente': '72974', '/omnibus-edicola': '114491', '/effetti-personali': '33311', '/quirinale': '106765',
+             '/elezioni': '32577', '/elezioni-amministrative-2021': '104639', '/elezioni-europee-2024': '117571', '/elezioni-politiche-2022': '109941', '/regionali2015': '65426',
+             '/elezioni-regionali-2020': '94442', '/elezioni-usa': '95091', '/eqelements': '114288', '/euro-dieci': '117427', '/europost': '119993', '/eventi-live': '116094',
+             '/speciali-ezio-mauro': '119401', '/facciaafaccia': '73973', '/famiglie-ditalia': '118714', '/film-e-fiction': '53050', '/food-maniac': '34470', '/webserie': '58781',
+             '/fuori-di-gusto': '34408', '/fuorionda': '69092', '/futbol': '72814', '/gazzetta-sports-awards': '74693', '/gigawatt': '118659', '/guerrieri': '52614', '/gustibus': '64469',
+             '/hawthorne': '85101', '/honestlygood': '82312', '/i-men%C3%B9-di-benedetta': '36443', '/i-responsabili': '109082', '/il-bello-delle-curve': '76901', '/il-boss-dei-comici': '67694',
+             '/il-commissario-cordier': '53311', '/il-gusto-di-sapere': '91393', '/il-mondo-che-verr%C3%A0': '37129', '/il-palio-di-siena': '109478', '/ilpolliceverdesonoio': '68548',
+              '/il-processo-di-biscardi': '112450', '/in-altre-parole': '114460', '/ricette-di-cucina': '58727', '/la-cucina-di-sonia': '97070', '/in-cucina-con-vissani': '42222', '/in-onda': '58737',
+             '/in-treatment': '57985', '/in-tv': '42300', '/in-viaggio-con-barbero': '114442', '/inarrestabili': '58625', '/inchieste-da-fermo': '113584', '/indovina-cosa-sceglie-la-sposa': '75632',
+             '/innovation': '36568', '/inseparabili': '101261', '/intanto': '101263', '/italia-fashion-show': '55904', '/josephineangegardien': '77994', '/kataklo': '90255', '/laria-che-tira': '38052',
+             '/lariadestate': '66668', '/lerba-del-vicino': '56552', '/lingrediente-perfetto': '86510', '/lofficina-delle-erbe': '74825', '/lora-della-salute': '75316','/lunionefalaforza': '86454',
+             '/la-caduta': '115146', '/le-copertine-di-crozza': '66697', '/la-corsa-al-voto': '109702', '/lafelicitanoneunatruffa': '82920', '/la-gabbia': '52618', '/la-gaia-scienza': '38026',
+             '/la-mala-educaxxxion': '56214', '/la-mala-educaxxxion-la7d': '38317', '/la-torre-di-babele': '114981', '/la-torre-di-babele-doc': '118783', '/la7cult': '111885', '/la7-cult': '26075',
+             '/la7magazine': '63005', '/la7ricorda': '83508', '/la7racconta': '72941', '/la7speciali': '102882', '/la7venti': '103095', '/le-invasioni-barbariche': '38071',
+             '/le-parole-della-salute': '91908', '/libri-in-onda': '111130', '/like': '84156', '/linea-gialla': '38501', '/lingo': '109910', '/little-murders': '81521', '/magazine7': '64468',
+             '/mamma-mia-che-settimana': '43996', '/marxisti-tendenza-groucho': '48797', '/meravigliosamente': '78387', '/meteo-della-sera': '93826', '/meteola7': '60540',
+             '/mica-pizza-e-fichi': '86104', '/miss-italia': '52620', '/miss-marple': '109479', '/missione-natura': '42849', '/mode-e-modi': '58403', '/mondo-senza-fine': '54093',
+             '/motorstorie': '111088', '/nene-e-margherita': '49131', '/niente-ferma-le-donne': '75540', '/non-ditelo-alla-sposa': '54990', '/nonelarena': '78932',
+             '/oliver-stone-nuclear-now': '115049', '/omnibus': '43855', '/oroscopo': '53863', '/otto-e-mezzo': '45098', '/our-godfather': '85928', '/padre-brown': '109373', '/piazzapulita': '42851',
+             '/pinkisgood': '78693', '/trash-it': '76993', '/propagandalive': '78368', '/quattrodonneeunfunerale': '54398', '/raffaella-carra': '103352', '/recital-di-corrado-guzzanti': '53862',
+             '/rigenerazione': '115362', '/figworldcup': '84181', '/roshn-saudi-league': '114296', '/royal-wedding': '81166', '/sconosciuti': '116192', '/se-stasera-sono-qui': '45749',
+             '/selfiefood': '79476', '/sempre-meglio-che-restare-a-casa': '112451', '/senti-chi-mangia': '92485', '/sfera': '71860', '/si-parla-di': '83927', '/skroll': '78278',
+             '/specialguest': '66670', '/speciali': '55153', '/speciali-mentana': '45796', '/startupeconomy': '91462', '/storie-dellaltro-social': '112291', '/storie-di-grandi-chef': '42921',
+             '/storie-di-palazzi': '110336', '/syusy-e-patrizio-news': '118758', '/tacco12enonsolo': '72605', '/taga-doc': '87967', '/tagada': '67838', '/taste-il-gusto-delleccellenza': '116662',
+             '/tgla7': '52619', '/the-dr-oz-show': '87313', '/the-show-must-go-off': '42865', '/ti-ci-porto-io': '46132', '/trumpstory': '119618', '/un-dolce-da-maestro': '84410',
+             '/una-giornata-particolare': '109868', '/uno-maggio-taranto-liberi-e-pensanti': '91830', '/uozzap': '81522', '/urban-scouters': '109003', '/vado-a-vivere-in-montagna': '85810',
+             '/varcondicio': '79932', '/victor-victoria': '42868', '/voicetown': '100017', '/voto-piu-voto-meno': '119921', '/welovecinema': '60262', '/zeta': '46396'}
+        program_details = {}
+        def fetch_program_data(path, tid):
+            url = f"https://www.la7.it/appla7/service_propertysmarttv?s=hbbtv&field_property_tid={tid}"
+            try:
+                data = json.loads(httptools.downloadpage(url).data)
+                if data and isinstance(data, list):  # Ensure data is a non-empty list
+                    item = data[0]
+                    return path, {
+                        "titolo": html.unescape(item.get("titolo", "")),
+                        "testo": html.unescape(item.get("testo", "")),
+                        "img": item.get("img", "").split('src="')[1].split('"')[0] if 'src="' in item.get("img", "") else "",
+                        "img_verticale": item.get("img_verticale", "").split('src="')[1].split('"')[0] if 'src="' in item.get("img_verticale", "") else "",
+                    }
+            except Exception as e:
+                return path, None  # Return None if request or parsing fails
+
+        # Use ThreadPoolExecutor for parallel requests
+        with futures.ThreadPoolExecutor() as executor:
+            future_to_path = {executor.submit(fetch_program_data, path, tid): path for path, tid in tids.items()}
+            
+            for future in futures.as_completed(future_to_path):
+                path, data = future.result()
+                if data:
+                    program_details[path] = data
         patron = r'<a href="(?P<url>[^"]+)"[^>]+><div class="[^"]+" data-background-image="(?P<thumb>[^"]+)"'
 
     match = support.match(html_content, patron=patron)
@@ -151,9 +208,21 @@ def peliculas(item):
     for n, key in enumerate(matches):
         if 'la7teche' in item.url:
             programma_url, titolo, thumb = key
+            plot = ""
+            fanart = ""
         else:
             programma_url, thumb = key
-            titolo = " ".join(programma_url.replace("/", "").split('-')).title()
+            if programma_url in program_details:
+                pinfo = program_details[programma_url]
+                titolo = pinfo['titolo'] if pinfo['titolo'] else " ".join(programma_url.replace("/", "").split('-')).title()
+                plot = pinfo['testo']
+                thumb = pinfo['img'] if pinfo['img'] else thumb
+                fanart = pinfo['img_verticale']
+            else:
+                titolo = " ".join(programma_url.replace("/", "").split('-')).title()
+                plot = ""
+                thumb = ""
+                fanart = ""
 
         if not thumb.startswith("https://"):
             thumb = f'{host}/{thumb}'
@@ -164,7 +233,9 @@ def peliculas(item):
                         data='',
                         fulltitle=titolo,
                         show=titolo,
+                        plot = plot,
                         thumbnail=thumb,
+                        fanart = fanart,
                         url=programma_url,
                         video_url=programma_url,
                         order=n)


### PR DESCRIPTION
1. Ho scoperto delle API che possono essere utilizzare per riempire parzialmente i titoli della sezione programmi, queste API sono molto piu' veloci che fare scraping dal sito. L'unica pecca e' che non esiste un modo efficiente per raccogliere tutti gli id dei programmi durante l'esecuzione del plugin, per questo e' necessario creare un dizionario cache.

2. fix per la preview delle dirette usando le API

P.S. Domanda Off Topic: accettate anche canali regionali e locali come channel provider?